### PR TITLE
Fix build on Linux

### DIFF
--- a/include/cutest.h
+++ b/include/cutest.h
@@ -75,6 +75,9 @@
     #define CUTEST_UNIX__    1
     #include <errno.h>
     #include <unistd.h>
+    #include <sys/types.h>
+    #include <sys/wait.h>
+    #include <signal.h>
 #endif
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)


### PR DESCRIPTION
POSIX says SIGSEGV et al come from signal.h, and waitpid comes from sys/types.h (for pid_t) and sys/wait.h.

http://pubs.opengroup.org/onlinepubs/009696699/basedefs/signal.h.html
http://pubs.opengroup.org/onlinepubs/7908799/xsh/waitpid.html

Now the examples build on linux. Before they failed to build with:

```
$ make
gcc -I../include  -Wall -static c-example.c ../include/cutest.h -o c-example
In file included from c-example.c:2:0:
../include/cutest.h: In function ‘test_run__’:
../include/cutest.h:270:13: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
../include/cutest.h:281:26: error: ‘SIGINT’ undeclared (first use in this function)
../include/cutest.h:281:26: note: each undeclared identifier is reported only once for each function it appears in
../include/cutest.h:282:26: error: ‘SIGHUP’ undeclared (first use in this function)
../include/cutest.h:283:26: error: ‘SIGQUIT’ undeclared (first use in this function)
../include/cutest.h:284:26: error: ‘SIGABRT’ undeclared (first use in this function)
../include/cutest.h:285:26: error: ‘SIGKILL’ undeclared (first use in this function)
../include/cutest.h:286:26: error: ‘SIGSEGV’ undeclared (first use in this function)
../include/cutest.h:287:26: error: ‘SIGILL’ undeclared (first use in this function)
../include/cutest.h:288:26: error: ‘SIGTERM’ undeclared (first use in this function)
../include/cutest.h: In function ‘test_run__’:
../include/cutest.h:270:13: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
../include/cutest.h:281:26: error: ‘SIGINT’ undeclared (first use in this function)
../include/cutest.h:281:26: note: each undeclared identifier is reported only once for each function it appears in
../include/cutest.h:282:26: error: ‘SIGHUP’ undeclared (first use in this function)
../include/cutest.h:283:26: error: ‘SIGQUIT’ undeclared (first use in this function)
../include/cutest.h:284:26: error: ‘SIGABRT’ undeclared (first use in this function)
../include/cutest.h:285:26: error: ‘SIGKILL’ undeclared (first use in this function)
../include/cutest.h:286:26: error: ‘SIGSEGV’ undeclared (first use in this function)
../include/cutest.h:287:26: error: ‘SIGILL’ undeclared (first use in this function)
../include/cutest.h:288:26: error: ‘SIGTERM’ undeclared (first use in this function)
make: *** [c-example] Error 1
```
