### PR TITLE
Xunit support

### DIFF
--- a/examples/cpp-example.cc
+++ b/examples/cpp-example.cc
@@ -103,9 +103,15 @@ void test_uncaught_strange_exception(void)
     some_function(THROW_CHAR_PTR, "Acutest knows how to catch me :-)");
 }
 
+void test_success(void)
+{
+    /* Do nothing */
+}
+
 TEST_LIST = {
     { "test_exception_type", test_exception_type },
     { "uncaught-std-exception", test_uncaught_std_exception },
     { "uncaught-strange-exception", test_uncaught_strange_exception },
+    { "success", test_success },
     { NULL, NULL }
 };

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -263,9 +263,9 @@ struct test__ {
 };
 
 enum {
-    TEST_FLAG_RUN = 1 << 0,
-    TEST_FLAG_SUCCESS = 1 << 1,
-    TEST_FLAG_FAILURE = 1 << 2,
+    TEST_FLAG_RUN__ = 1 << 0,
+    TEST_FLAG_SUCCESS__ = 1 << 1,
+    TEST_FLAG_FAILURE__ = 1 << 2,
 };
 
 extern const struct test__ test_list__[];
@@ -716,17 +716,17 @@ test_list_names__(void)
 static void
 test_remember__(int i)
 {
-    if(test_flags__[i] & TEST_FLAG_RUN)
+    if(test_flags__[i] & TEST_FLAG_RUN__)
         return;
 
-    test_flags__[i] |= TEST_FLAG_RUN;
+    test_flags__[i] |= TEST_FLAG_RUN__;
     test_count__++;
 }
 
 static void
 test_set_success__(int i, int success)
 {
-    test_flags__[i] |= success ? TEST_FLAG_SUCCESS : TEST_FLAG_FAILURE;
+    test_flags__[i] |= success ? TEST_FLAG_SUCCESS__ : TEST_FLAG_FAILURE__;
 }
 
 static int
@@ -1479,7 +1479,7 @@ main(int argc, char** argv)
 
     int index = test_worker_index__;
     for(i = 0; test_list__[i].func != NULL; i++) {
-        int run = (test_flags__[i] & TEST_FLAG_RUN);
+        int run = (test_flags__[i] & TEST_FLAG_RUN__);
         if (test_skip_mode__) /* Run all tests except those listed. */
             run = !run;
         if(run)
@@ -1519,9 +1519,9 @@ main(int argc, char** argv)
         for(i = 0; test_list__[i].func != NULL; i++) {
             fprintf(test_xml_output__, "  <testcase name=\"%s\">\n",
             test_list__[i].name);
-            if (test_flags__[i] & TEST_FLAG_FAILURE)
+            if (test_flags__[i] & TEST_FLAG_FAILURE__)
                 fprintf(test_xml_output__, "    <failure />\n");
-            if (!(test_flags__[i] & TEST_FLAG_FAILURE) && !(test_flags__[i] & TEST_FLAG_SUCCESS))
+            if (!(test_flags__[i] & TEST_FLAG_FAILURE__) && !(test_flags__[i] & TEST_FLAG_SUCCESS__))
                 fprintf(test_xml_output__, "    <skipped />\n");
             fprintf(test_xml_output__, "  </testcase>\n");
         }

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1328,7 +1328,11 @@ test_cmdline_callback__(int id, const char* arg)
             test_worker_index__ = atoi(arg);
             break;
         case 'x':
-            test_xml_output__ = fopen(arg, "wb");
+            test_xml_output__ = fopen(arg, "w");
+            if (!test_xml_output__) {
+                fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
+                exit(2);
+            }
             break;
 
         case 0:
@@ -1513,14 +1517,11 @@ main(int argc, char** argv)
             (int)test_list_size__, test_stat_failed_units__, test_stat_failed_units__,
             (int)test_list_size__ - test_stat_run_units__);
         for(i = 0; test_list__[i].func != NULL; i++) {
-            int run = (test_flags__[i] & TEST_FLAG_RUN);
-            if (test_skip_mode__) /* Run all tests except those listed. */
-                run = !run;
             fprintf(test_xml_output__, "  <testcase name=\"%s\">\n",
             test_list__[i].name);
             if (test_flags__[i] & TEST_FLAG_FAILURE)
                 fprintf(test_xml_output__, "    <failure />\n");
-            if (!run)
+            if (!(test_flags__[i] & TEST_FLAG_FAILURE) && !(test_flags__[i] & TEST_FLAG_SUCCESS))
                 fprintf(test_xml_output__, "    <skipped />\n");
             fprintf(test_xml_output__, "  </testcase>\n");
         }


### PR DESCRIPTION
Useful for integration into CI systems. Doesn't currently capture the actual error messages.

In the process I've also removed the 'tests__' copy of test_list__ and just use the flags instead. I don't think this will have a significant impact, but I'm open to comments. It makes it easier to know which index you're at for setting the SUCCESS/FAILURE flags.

The more complex next step would be to capture the output of each command and save it in a buffer to jam into the report. At this stage I've just left that, so people will need to look at the logs to see the details of the error.