### PR TITLE
Added per-test timing support

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -263,7 +263,7 @@ struct test__ {
 };
 
 struct test_detail__ {
-    uint8_t flags;
+    unsigned char flags;
     double duration;
 };
 


### PR DESCRIPTION
Replaced test_flags__ with a per-test test_detail__ structure.
Use this for both flags & holding timing information.
This allows us to add the timing information to the xml report.