### PR TITLE
Fixes for timing and clang-tidy use.

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -22,6 +22,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+/*
+ * Portions Copyright 2019 Garrett D'Amore
+ */
 
 #ifndef ACUTEST_H__
 #define ACUTEST_H__
@@ -178,7 +181,7 @@
  * the last test case after exiting the loop), you may use TEST_CASE(NULL).
  */
 #define TEST_CASE_(...)         test_case__(__VA_ARGS__)
-#define TEST_CASE(name)         test_case__("%s", name);
+#define TEST_CASE(name)         test_case__("%s", name)
 
 
 /* printf-like macro for outputting an extra information about a failure.
@@ -364,8 +367,8 @@ static jmp_buf test_abort_jmp_buf__;
     static double
     test_timer_diff__(LARGE_INTEGER start, LARGE_INTEGER end)
     {
-        double duration = end.QuadPart - start.QuadPart;
-        duration /= test_timer_freq__.QuadPart;
+        double duration = (double)(end.QuadPart - start.QuadPart);
+        duration /= (double)test_timer_freq__.QuadPart;
         return duration;
     }
 
@@ -384,12 +387,7 @@ static jmp_buf test_abort_jmp_buf__;
     test_timer_init__(void)
     {
         if(test_timer__ == 1)
-    #ifdef CLOCK_MONOTONIC_RAW
-            /* linux specific; not subject of NTP adjustments or adjtime() */
-            test_timer_id__ = CLOCK_MONOTONIC_RAW;
-    #else
             test_timer_id__ = CLOCK_MONOTONIC;
-    #endif
         else if(test_timer__ == 2)
             test_timer_id__ = CLOCK_PROCESS_CPUTIME_ID;
     }
@@ -403,11 +401,18 @@ static jmp_buf test_abort_jmp_buf__;
     static double
     test_timer_diff__(struct timespec start, struct timespec end)
     {
-        return ((double) end.tv_sec +
-                (double) end.tv_nsec * 10e-9)
-               -
-               ((double) start.tv_sec +
-                (double) start.tv_nsec * 10e-9);
+        double endns;
+        double startns;
+
+        endns = end.tv_sec;
+        endns *= 1e9;
+        endns += end.tv_nsec;
+
+        startns = start.tv_sec;
+        startns *= 1e9;
+        startns += start.tv_nsec;
+
+        return ((endns - startns)/ 1e9);
     }
 
     static void

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -3,6 +3,7 @@
  * <http://github.com/mity/acutest>
  *
  * Copyright (c) 2013-2019 Martin Mitas
+ * Copyright 2019 Garrett D'Amore
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -21,9 +22,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
- */
-/*
- * Portions Copyright 2019 Garrett D'Amore
  */
 
 #ifndef ACUTEST_H__


### PR DESCRIPTION
fixes #28 Timing calculations are wrong
fixes #29 TEST_CASE should evaluate as a statement (no trailing semicolon)

I've added my copyright as a "Portions" bit.  If you prefer to instead just have me add a Copyright line below yours (how I do it for my repos), please let me know (or just make the change yourself).

Meaning, I'm also happy with:

```
 * Copyright (c) 2013-2019 Martin Mitas
 * Copyright 2019 Garrett D'Amore 
 *
 * ... license text follows
```

Oh, and thanks for your work on this project -- I'm now using it in NNG (as you know), and have begin replacing my own framework (c-convey -- see github.com/gdamore/c-convey) with it as this is simply easier to use and debug.

As an aside, the "(c)" in your copyright statement is actually useless (following a bad practice started by companies years ago who should have known better).   Because (c) is not recognized as the copyright symbol, and even if it were, it is entirely redundant to the word "Copyright" in copyright law.  (The symbol was intended for uses where a shorthand substitute for the word "Copyright" was desired.)