### PR TITLE
Add functions that are called before/after every test

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -925,6 +925,26 @@ test_error_(const char* fmt, ...)
     }
 }
 
+/* This is called just before each test */
+static void
+test_init_(const char *test_name)
+{
+#ifdef TEST_INIT
+  TEST_INIT
+  ; /* Allow for a single unterminated function call */
+#endif
+}
+
+/* This is called after each test */
+static void
+test_fini_(const char *test_name)
+{
+#ifdef TEST_FINI
+  TEST_FINI
+  ; /* Allow for a single unterminated function call */
+#endif
+}
+
 /* Call directly the given test unit function. */
 static int
 test_do_run_(const struct test_* test, int index)
@@ -936,13 +956,13 @@ test_do_run_(const struct test_* test, int index)
     test_current_already_logged_ = 0;
     test_cond_failed_ = 0;
 
-    test_begin_test_line_(test);
-
 #ifdef __cplusplus
     try {
 #endif
+        test_init_(test->name);
+        test_begin_test_line_(test);
 
-        /* This is good to do for case the test unit e.g. crashes. */
+        /* This is good to do in case the test unit crashes. */
         fflush(stdout);
         fflush(stderr);
 
@@ -988,6 +1008,7 @@ aborted:
             test_finish_test_line_(0);
         }
 
+        test_fini_(test->name);
         test_case_(NULL);
         test_current_unit_ = NULL;
         return (test_current_failures_ == 0) ? 0 : -1;


### PR DESCRIPTION
- `test_global_init()` is called before every test
- `test_global_fini()` is called after every test

The user can define code to be called by defining `TEST_GLOBAL_INIT`
and/or `TEST_GLOBAL_FINI`.

```c
#ifdef TEST_GLOBAL_INIT { printf("before %s\n", test_case); }
#ifdef TEST_GLOBAL_FINI { printf("after %s\n", test_case); }

#include "acutest.h"
```

Closes: #46 

---

I've implemented the functions as you suggested and they work nicely.
A few notes:

- The `test_global_init()` is inside the `try` block.
  I moved the `test_begin_test_line_()` call after so that the `test... [OK]` line won't get split up.

- The `test_global_fini()` is also inside the `try` block.
  This means it won't get called after a crash, probably not a problem :-)

- I dropped the lone `;` since that will lead to build warnings.
  The user code needs to be syntactically correct.

- I added the parameter `const char *test_name`.
  The user functions could have use of it.
