### PR TITLE
Remove header specification from add_executable in CMake

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
 
-add_executable(c-example c-example.c ../include/acutest.h)
-add_executable(cpp-example cpp-example.cc ../include/acutest.h)
+add_executable(c-example c-example.c)
+add_executable(cpp-example cpp-example.cc)


### PR DESCRIPTION
Do we actually need pass header to add_executable ?