### PR TITLE
fix broken OS detection

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -294,7 +294,7 @@
     #endif
 #endif
 
-#if defined(_gnu_linux_)
+#if defined(_gnu_linux_) || defined(__linux__)
     #define ACUTEST_LINUX_      1
     #include <fcntl.h>
     #include <sys/stat.h>


### PR DESCRIPTION
g++ 10 on ubuntu was not producing the expected #define