### PR TITLE
Fix -Wmissing-noreturn with clang11

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -404,7 +404,7 @@ test_cleanup_(void)
     free((void*) test_details_);
 }
 
-static void
+static void TEST_ATTRIBUTE_(noreturn)
 test_exit_(int exit_code)
 {
     test_cleanup_();


### PR DESCRIPTION
As per title, fixes:

```
src/freeradius-devel/util/acutest.h:409:1: warning: function 'test_exit_' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
{
^
1 warning generated.
```