### PR TITLE
Code cleanup.

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1118,7 +1118,7 @@ acutest_run_(const struct acutest_test_* test, int index, int master_index)
         } else if(pid == 0) {
             /* Child: Do the test. */
             acutest_worker_ = 1;
-            failed = (test_do_run_(test, index) != 0);
+            failed = (acutest_do_run_(test, index) != 0);
             acutest_exit_(failed ? 1 : 0);
         } else {
             /* Parent: Wait until child terminates and analyze its exit code. */

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -59,7 +59,7 @@
  *
  * Note the list has to be ended with a zeroed record.
  */
-#define TEST_LIST               const struct test_ test_list_[]
+#define TEST_LIST               const struct acutest_test_ acutest_list_[]
 
 
 /* Macros for testing whether an unit test succeeds or fails. These macros
@@ -81,8 +81,8 @@
  *       TEST_CHECK(ptr->member2 > 200);
  *   }
  */
-#define TEST_CHECK_(cond,...)   test_check_((cond), __FILE__, __LINE__, __VA_ARGS__)
-#define TEST_CHECK(cond)        test_check_((cond), __FILE__, __LINE__, "%s", #cond)
+#define TEST_CHECK_(cond,...)   acutest_check_((cond), __FILE__, __LINE__, __VA_ARGS__)
+#define TEST_CHECK(cond)        acutest_check_((cond), __FILE__, __LINE__, "%s", #cond)
 
 
 /* These macros are the same as TEST_CHECK_ and TEST_CHECK except that if the
@@ -102,13 +102,13 @@
  */
 #define TEST_ASSERT_(cond,...)                                                 \
     do {                                                                       \
-        if(!test_check_((cond), __FILE__, __LINE__, __VA_ARGS__))              \
-            test_abort_();                                                     \
+        if(!acutest_check_((cond), __FILE__, __LINE__, __VA_ARGS__))           \
+            acutest_abort_();                                                  \
     } while(0)
 #define TEST_ASSERT(cond)                                                      \
     do {                                                                       \
-        if(!test_check_((cond), __FILE__, __LINE__, "%s", #cond))              \
-            test_abort_();                                                     \
+        if(!acutest_check_((cond), __FILE__, __LINE__, "%s", #cond))           \
+            acutest_abort_();                                                  \
     } while(0)
 
 
@@ -139,9 +139,9 @@
         } catch(...) {                                                         \
             msg_ = "Unexpected exception thrown.";                             \
         }                                                                      \
-        test_check_(exc_ok_, __FILE__, __LINE__, #code " throws " #exctype);   \
+        acutest_check_(exc_ok_, __FILE__, __LINE__, #code " throws " #exctype);\
         if(msg_ != NULL)                                                       \
-            test_message_("%s", msg_);                                         \
+            acutest_message_("%s", msg_);                                      \
     } while(0)
 #define TEST_EXCEPTION_(code, exctype, ...)                                    \
     do {                                                                       \
@@ -155,9 +155,9 @@
         } catch(...) {                                                         \
             msg_ = "Unexpected exception thrown.";                             \
         }                                                                      \
-        test_check_(exc_ok_, __FILE__, __LINE__, __VA_ARGS__);                 \
+        acutest_check_(exc_ok_, __FILE__, __LINE__, __VA_ARGS__);              \
         if(msg_ != NULL)                                                       \
-            test_message_("%s", msg_);                                         \
+            acutest_message_("%s", msg_);                                      \
     } while(0)
 #endif  /* #ifdef __cplusplus */
 
@@ -180,8 +180,8 @@
  * implicitly the previous one. To end the test case explicitly (e.g. to end
  * the last test case after exiting the loop), you may use TEST_CASE(NULL).
  */
-#define TEST_CASE_(...)         test_case_(__VA_ARGS__)
-#define TEST_CASE(name)         test_case_("%s", name)
+#define TEST_CASE_(...)         acutest_case_(__VA_ARGS__)
+#define TEST_CASE(name)         acutest_case_("%s", name)
 
 
 /* Maximal output per TEST_CASE call. Longer messages are cut.
@@ -213,7 +213,7 @@
  * The macro can deal with multi-line output fairly well. It also automatically
  * adds a final new-line if there is none present.
  */
-#define TEST_MSG(...)           test_message_(__VA_ARGS__)
+#define TEST_MSG(...)           acutest_message_(__VA_ARGS__)
 
 
 /* Maximal output per TEST_MSG call. Longer messages are cut.
@@ -235,7 +235,7 @@
  *   TEST_DUMP("Expected:", addr_expected, size_expected);
  *   TEST_DUMP("Produced:", addr_produced, size_produced);
  */
-#define TEST_DUMP(title, addr, size)    test_dump_(title, addr, size)
+#define TEST_DUMP(title, addr, size)    acutest_dump_(title, addr, size)
 
 /* Maximal output per TEST_DUMP call (in bytes to dump). Longer blocks are cut.
  * You may define another limit prior including "acutest.h"
@@ -310,7 +310,6 @@
     #include <exception>
 #endif
 
-/* Load valgrind.h, if available. This allows to detect valgrind's presence via RUNNING_ON_VALGRIND. */
 #ifdef __has_include
     #if __has_include(<valgrind.h>)
         #include <valgrind.h>
@@ -319,9 +318,9 @@
 
 /* Enable the use of the non-standard keyword __attribute__ to silence warnings under some compilers */
 #if defined(__GNUC__) || defined(__clang__)
-    #define TEST_ATTRIBUTE_(attr)   __attribute__((attr))
+    #define ACUTEST_ATTRIBUTE_(attr)    __attribute__((attr))
 #else
-    #define TEST_ATTRIBUTE_(attr)
+    #define ACUTEST_ATTRIBUTE_(attr)
 #endif
 
 /* Note our global private identifiers end with '_' to mitigate risk of clash
@@ -340,131 +339,131 @@
 #endif
 
 
-struct test_ {
+struct acutest_test_ {
     const char* name;
     void (*func)(void);
 };
 
-struct test_detail_ {
+struct acutest_test_data_ {
     unsigned char flags;
     double duration;
 };
 
 enum {
-    TEST_FLAG_RUN_ = 1 << 0,
-    TEST_FLAG_SUCCESS_ = 1 << 1,
-    TEST_FLAG_FAILURE_ = 1 << 2,
+    ACUTEST_FLAG_RUN_ = 1 << 0,
+    ACUTEST_FLAG_SUCCESS_ = 1 << 1,
+    ACUTEST_FLAG_FAILURE_ = 1 << 2,
 };
 
-extern const struct test_ test_list_[];
+extern const struct acutest_test_ acutest_list_[];
 
-int test_check_(int cond, const char* file, int line, const char* fmt, ...);
-void test_case_(const char* fmt, ...);
-void test_message_(const char* fmt, ...);
-void test_dump_(const char* title, const void* addr, size_t size);
-void test_abort_(void) TEST_ATTRIBUTE_(noreturn);
+int acutest_check_(int cond, const char* file, int line, const char* fmt, ...);
+void acutest_case_(const char* fmt, ...);
+void acutest_message_(const char* fmt, ...);
+void acutest_dump_(const char* title, const void* addr, size_t size);
+void acutest_abort_(void) ACUTEST_ATTRIBUTE_(noreturn);
 
 
 #ifndef TEST_NO_MAIN
 
-static char* test_argv0_ = NULL;
-static size_t test_list_size_ = 0;
-static struct test_detail_ *test_details_ = NULL;
-static size_t test_count_ = 0;
-static int test_no_exec_ = -1;
-static int test_no_summary_ = 0;
-static int test_tap_ = 0;
-static int test_skip_mode_ = 0;
-static int test_worker_ = 0;
-static int test_worker_index_ = 0;
-static int test_cond_failed_ = 0;
-static int test_was_aborted_ = 0;
-static FILE *test_xml_output_ = NULL;
+static char* acutest_argv0_ = NULL;
+static size_t acutest_list_size_ = 0;
+static struct acutest_test_data_* acutest_test_data_ = NULL;
+static size_t acutest_count_ = 0;
+static int acutest_no_exec_ = -1;
+static int acutest_no_summary_ = 0;
+static int acutest_tap_ = 0;
+static int acutest_skip_mode_ = 0;
+static int acutest_worker_ = 0;
+static int acutest_worker_index_ = 0;
+static int acutest_cond_failed_ = 0;
+static int acutest_was_aborted_ = 0;
+static FILE *acutest_xml_output_ = NULL;
 
-static int test_stat_failed_units_ = 0;
-static int test_stat_run_units_ = 0;
+static int acutest_stat_failed_units_ = 0;
+static int acutest_stat_run_units_ = 0;
 
-static const struct test_* test_current_unit_ = NULL;
-static int test_current_index_ = 0;
-static char test_case_name_[TEST_CASE_MAXSIZE] = "";
-static int test_current_already_logged_ = 0;
-static int test_case_current_already_logged_ = 0;
-static int test_verbose_level_ = 2;
-static int test_current_failures_ = 0;
-static int test_colorize_ = 0;
-static int test_timer_ = 0;
+static const struct acutest_test_* acutest_current_test_ = NULL;
+static int acutest_current_index_ = 0;
+static char acutest_case_name_[TEST_CASE_MAXSIZE] = "";
+static int acutest_test_already_logged_ = 0;
+static int acutest_case_already_logged_ = 0;
+static int acutest_verbose_level_ = 2;
+static int acutest_test_failures_ = 0;
+static int acutest_colorize_ = 0;
+static int acutest_timer_ = 0;
 
-static int test_abort_has_jmp_buf_ = 0;
-static jmp_buf test_abort_jmp_buf_;
+static int acutest_abort_has_jmp_buf_ = 0;
+static jmp_buf acutest_abort_jmp_buf_;
 
 
 static void
-test_cleanup_(void)
+acutest_cleanup_(void)
 {
-    free((void*) test_details_);
+    free((void*) acutest_test_data_);
 }
 
-static void TEST_ATTRIBUTE_(noreturn)
-test_exit_(int exit_code)
+static void ACUTEST_ATTRIBUTE_(noreturn)
+acutest_exit_(int exit_code)
 {
-    test_cleanup_();
+    acutest_cleanup_();
     exit(exit_code);
 }
 
 #if defined ACUTEST_WIN_
-    typedef LARGE_INTEGER test_timer_type_;
-    static LARGE_INTEGER test_timer_freq_;
-    static test_timer_type_ test_timer_start_;
-    static test_timer_type_ test_timer_end_;
+    typedef LARGE_INTEGER acutest_timer_type_;
+    static LARGE_INTEGER acutest_timer_freq_;
+    static acutest_timer_type_ acutest_timer_start_;
+    static acutest_timer_type_ acutest_timer_end_;
 
     static void
-    test_timer_init_(void)
+    acutest_timer_init_(void)
     {
-        QueryPerformanceFrequency(&test_timer_freq_);
+        QueryPerformanceFrequency(&acutest_timer_freq_);
     }
 
     static void
-    test_timer_get_time_(LARGE_INTEGER* ts)
+    acutest_timer_get_time_(LARGE_INTEGER* ts)
     {
         QueryPerformanceCounter(ts);
     }
 
     static double
-    test_timer_diff_(LARGE_INTEGER start, LARGE_INTEGER end)
+    acutest_timer_diff_(LARGE_INTEGER start, LARGE_INTEGER end)
     {
         double duration = (double)(end.QuadPart - start.QuadPart);
-        duration /= (double)test_timer_freq_.QuadPart;
+        duration /= (double)acutest_timer_freq_.QuadPart;
         return duration;
     }
 
     static void
-    test_timer_print_diff_(void)
+    acutest_timer_print_diff_(void)
     {
-        printf("%.6lf secs", test_timer_diff_(test_timer_start_, test_timer_end_));
+        printf("%.6lf secs", acutest_timer_diff_(acutest_timer_start_, acutest_timer_end_));
     }
 #elif defined ACUTEST_HAS_POSIX_TIMER_
-    static clockid_t test_timer_id_;
-    typedef struct timespec test_timer_type_;
-    static test_timer_type_ test_timer_start_;
-    static test_timer_type_ test_timer_end_;
+    static clockid_t acutest_timer_id_;
+    typedef struct timespec acutest_timer_type_;
+    static acutest_timer_type_ acutest_timer_start_;
+    static acutest_timer_type_ acutest_timer_end_;
 
     static void
-    test_timer_init_(void)
+    acutest_timer_init_(void)
     {
-        if(test_timer_ == 1)
-            test_timer_id_ = CLOCK_MONOTONIC;
-        else if(test_timer_ == 2)
-            test_timer_id_ = CLOCK_PROCESS_CPUTIME_ID;
+        if(acutest_timer_ == 1)
+            acutest_timer_id_ = CLOCK_MONOTONIC;
+        else if(acutest_timer_ == 2)
+            acutest_timer_id_ = CLOCK_PROCESS_CPUTIME_ID;
     }
 
     static void
-    test_timer_get_time_(struct timespec* ts)
+    acutest_timer_get_time_(struct timespec* ts)
     {
-        clock_gettime(test_timer_id_, ts);
+        clock_gettime(acutest_timer_id_, ts);
     }
 
     static double
-    test_timer_diff_(struct timespec start, struct timespec end)
+    acutest_timer_diff_(struct timespec start, struct timespec end)
     {
         double endns;
         double startns;
@@ -481,28 +480,28 @@ test_exit_(int exit_code)
     }
 
     static void
-    test_timer_print_diff_(void)
+    acutest_timer_print_diff_(void)
     {
         printf("%.6lf secs",
-            test_timer_diff_(test_timer_start_, test_timer_end_));
+            acutest_timer_diff_(acutest_timer_start_, acutest_timer_end_));
     }
 #else
-    typedef int test_timer_type_;
-    static test_timer_type_ test_timer_start_;
-    static test_timer_type_ test_timer_end_;
+    typedef int acutest_timer_type_;
+    static acutest_timer_type_ acutest_timer_start_;
+    static acutest_timer_type_ acutest_timer_end_;
 
     void
-    test_timer_init_(void)
+    acutest_timer_init_(void)
     {}
 
     static void
-    test_timer_get_time_(int* ts)
+    acutest_timer_get_time_(int* ts)
     {
         (void) ts;
     }
 
     static double
-    test_timer_diff_(int start, int end)
+    acutest_timer_diff_(int start, int end)
     {
         (void) start;
         (void) end;
@@ -510,19 +509,19 @@ test_exit_(int exit_code)
     }
 
     static void
-    test_timer_print_diff_(void)
+    acutest_timer_print_diff_(void)
     {}
 #endif
 
-#define TEST_COLOR_DEFAULT_             0
-#define TEST_COLOR_GREEN_               1
-#define TEST_COLOR_RED_                 2
-#define TEST_COLOR_DEFAULT_INTENSIVE_   3
-#define TEST_COLOR_GREEN_INTENSIVE_     4
-#define TEST_COLOR_RED_INTENSIVE_       5
+#define ACUTEST_COLOR_DEFAULT_              0
+#define ACUTEST_COLOR_GREEN_                1
+#define ACUTEST_COLOR_RED_                  2
+#define ACUTEST_COLOR_DEFAULT_INTENSIVE_    3
+#define ACUTEST_COLOR_GREEN_INTENSIVE_      4
+#define ACUTEST_COLOR_RED_INTENSIVE_        5
 
-static int TEST_ATTRIBUTE_(format (printf, 2, 3))
-test_print_in_color_(int color, const char* fmt, ...)
+static int ACUTEST_ATTRIBUTE_(format (printf, 2, 3))
+acutest_colored_printf_(int color, const char* fmt, ...)
 {
     va_list args;
     char buffer[256];
@@ -533,7 +532,7 @@ test_print_in_color_(int color, const char* fmt, ...)
     va_end(args);
     buffer[sizeof(buffer)-1] = '\0';
 
-    if(!test_colorize_) {
+    if(!acutest_colorize_) {
         return printf("%s", buffer);
     }
 
@@ -541,12 +540,12 @@ test_print_in_color_(int color, const char* fmt, ...)
     {
         const char* col_str;
         switch(color) {
-            case TEST_COLOR_GREEN_:             col_str = "\033[0;32m"; break;
-            case TEST_COLOR_RED_:               col_str = "\033[0;31m"; break;
-            case TEST_COLOR_GREEN_INTENSIVE_:   col_str = "\033[1;32m"; break;
-            case TEST_COLOR_RED_INTENSIVE_:     col_str = "\033[1;31m"; break;
-            case TEST_COLOR_DEFAULT_INTENSIVE_: col_str = "\033[1m"; break;
-            default:                            col_str = "\033[0m"; break;
+            case ACUTEST_COLOR_GREEN_:              col_str = "\033[0;32m"; break;
+            case ACUTEST_COLOR_RED_:                col_str = "\033[0;31m"; break;
+            case ACUTEST_COLOR_GREEN_INTENSIVE_:    col_str = "\033[1;32m"; break;
+            case ACUTEST_COLOR_RED_INTENSIVE_:      col_str = "\033[1;31m"; break;
+            case ACUTEST_COLOR_DEFAULT_INTENSIVE_:  col_str = "\033[1m"; break;
+            default:                                col_str = "\033[0m"; break;
         }
         printf("%s", col_str);
         n = printf("%s", buffer);
@@ -563,12 +562,12 @@ test_print_in_color_(int color, const char* fmt, ...)
         GetConsoleScreenBufferInfo(h, &info);
 
         switch(color) {
-            case TEST_COLOR_GREEN_:             attr = FOREGROUND_GREEN; break;
-            case TEST_COLOR_RED_:               attr = FOREGROUND_RED; break;
-            case TEST_COLOR_GREEN_INTENSIVE_:   attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
-            case TEST_COLOR_RED_INTENSIVE_:     attr = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            case TEST_COLOR_DEFAULT_INTENSIVE_: attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            default:                            attr = 0; break;
+            case ACUTEST_COLOR_GREEN_:              attr = FOREGROUND_GREEN; break;
+            case ACUTEST_COLOR_RED_:                attr = FOREGROUND_RED; break;
+            case ACUTEST_COLOR_GREEN_INTENSIVE_:    attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
+            case ACUTEST_COLOR_RED_INTENSIVE_:      attr = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
+            case ACUTEST_COLOR_DEFAULT_INTENSIVE_:  attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY; break;
+            default:                                attr = 0; break;
         }
         if(attr != 0)
             SetConsoleTextAttribute(h, attr);
@@ -583,49 +582,49 @@ test_print_in_color_(int color, const char* fmt, ...)
 }
 
 static void
-test_begin_test_line_(const struct test_* test)
+acutest_begin_test_line_(const struct acutest_test_* test)
 {
-    if(!test_tap_) {
-        if(test_verbose_level_ >= 3) {
-            test_print_in_color_(TEST_COLOR_DEFAULT_INTENSIVE_, "Test %s:\n", test->name);
-            test_current_already_logged_++;
-        } else if(test_verbose_level_ >= 1) {
+    if(!acutest_tap_) {
+        if(acutest_verbose_level_ >= 3) {
+            acutest_colored_printf_(ACUTEST_COLOR_DEFAULT_INTENSIVE_, "Test %s:\n", test->name);
+            acutest_test_already_logged_++;
+        } else if(acutest_verbose_level_ >= 1) {
             int n;
             char spaces[48];
 
-            n = test_print_in_color_(TEST_COLOR_DEFAULT_INTENSIVE_, "Test %s... ", test->name);
+            n = acutest_colored_printf_(ACUTEST_COLOR_DEFAULT_INTENSIVE_, "Test %s... ", test->name);
             memset(spaces, ' ', sizeof(spaces));
             if(n < (int) sizeof(spaces))
                 printf("%.*s", (int) sizeof(spaces) - n, spaces);
         } else {
-            test_current_already_logged_ = 1;
+            acutest_test_already_logged_ = 1;
         }
     }
 }
 
 static void
-test_finish_test_line_(int result)
+acutest_finish_test_line_(int result)
 {
-    if(test_tap_) {
+    if(acutest_tap_) {
         const char* str = (result == 0) ? "ok" : "not ok";
 
-        printf("%s %d - %s\n", str, test_current_index_ + 1, test_current_unit_->name);
+        printf("%s %d - %s\n", str, acutest_current_index_ + 1, acutest_current_test_->name);
 
-        if(result == 0  &&  test_timer_) {
+        if(result == 0  &&  acutest_timer_) {
             printf("# Duration: ");
-            test_timer_print_diff_();
+            acutest_timer_print_diff_();
             printf("\n");
         }
     } else {
-        int color = (result == 0) ? TEST_COLOR_GREEN_INTENSIVE_ : TEST_COLOR_RED_INTENSIVE_;
+        int color = (result == 0) ? ACUTEST_COLOR_GREEN_INTENSIVE_ : ACUTEST_COLOR_RED_INTENSIVE_;
         const char* str = (result == 0) ? "OK" : "FAILED";
         printf("[ ");
-        test_print_in_color_(color, "%s", str);
+        acutest_colored_printf_(color, "%s", str);
         printf(" ]");
 
-        if(result == 0  &&  test_timer_) {
+        if(result == 0  &&  acutest_timer_) {
             printf("  ");
-            test_timer_print_diff_();
+            acutest_timer_print_diff_();
         }
 
         printf("\n");
@@ -633,12 +632,12 @@ test_finish_test_line_(int result)
 }
 
 static void
-test_line_indent_(int level)
+acutest_line_indent_(int level)
 {
     static const char spaces[] = "                ";
     int n = level * 2;
 
-    if(test_tap_  &&  n > 0) {
+    if(acutest_tap_  &&  n > 0) {
         n--;
         printf("#");
     }
@@ -650,8 +649,8 @@ test_line_indent_(int level)
     printf("%.*s", n, spaces);
 }
 
-int TEST_ATTRIBUTE_(format (printf, 4, 5))
-test_check_(int cond, const char* file, int line, const char* fmt, ...)
+int ACUTEST_ATTRIBUTE_(format (printf, 4, 5))
+acutest_check_(int cond, const char* file, int line, const char* fmt, ...)
 {
     const char *result_str;
     int result_color;
@@ -659,30 +658,30 @@ test_check_(int cond, const char* file, int line, const char* fmt, ...)
 
     if(cond) {
         result_str = "ok";
-        result_color = TEST_COLOR_GREEN_;
+        result_color = ACUTEST_COLOR_GREEN_;
         verbose_level = 3;
     } else {
-        if(!test_current_already_logged_  &&  test_current_unit_ != NULL)
-            test_finish_test_line_(-1);
+        if(!acutest_test_already_logged_  &&  acutest_current_test_ != NULL)
+            acutest_finish_test_line_(-1);
 
         result_str = "failed";
-        result_color = TEST_COLOR_RED_;
+        result_color = ACUTEST_COLOR_RED_;
         verbose_level = 2;
-        test_current_failures_++;
-        test_current_already_logged_++;
+        acutest_test_failures_++;
+        acutest_test_already_logged_++;
     }
 
-    if(test_verbose_level_ >= verbose_level) {
+    if(acutest_verbose_level_ >= verbose_level) {
         va_list args;
 
-        if(!test_case_current_already_logged_  &&  test_case_name_[0]) {
-            test_line_indent_(1);
-            test_print_in_color_(TEST_COLOR_DEFAULT_INTENSIVE_, "Case %s:\n", test_case_name_);
-            test_current_already_logged_++;
-            test_case_current_already_logged_++;
+        if(!acutest_case_already_logged_  &&  acutest_case_name_[0]) {
+            acutest_line_indent_(1);
+            acutest_colored_printf_(ACUTEST_COLOR_DEFAULT_INTENSIVE_, "Case %s:\n", acutest_case_name_);
+            acutest_test_already_logged_++;
+            acutest_case_already_logged_++;
         }
 
-        test_line_indent_(test_case_name_[0] ? 2 : 1);
+        acutest_line_indent_(acutest_case_name_[0] ? 2 : 1);
         if(file != NULL) {
 #ifdef ACUTEST_WIN_
             const char* lastsep1 = strrchr(file, '\\');
@@ -705,58 +704,58 @@ test_check_(int cond, const char* file, int line, const char* fmt, ...)
         va_end(args);
 
         printf("... ");
-        test_print_in_color_(result_color, "%s", result_str);
+        acutest_colored_printf_(result_color, "%s", result_str);
         printf("\n");
-        test_current_already_logged_++;
+        acutest_test_already_logged_++;
     }
 
-    test_cond_failed_ = (cond == 0);
-    return !test_cond_failed_;
+    acutest_cond_failed_ = (cond == 0);
+    return !acutest_cond_failed_;
 }
 
-void TEST_ATTRIBUTE_(format (printf, 1, 2))
-test_case_(const char* fmt, ...)
+void ACUTEST_ATTRIBUTE_(format (printf, 1, 2))
+acutest_case_(const char* fmt, ...)
 {
     va_list args;
 
-    if(test_verbose_level_ < 2)
+    if(acutest_verbose_level_ < 2)
         return;
 
-    if(test_case_name_[0]) {
-        test_case_current_already_logged_ = 0;
-        test_case_name_[0] = '\0';
+    if(acutest_case_name_[0]) {
+        acutest_case_already_logged_ = 0;
+        acutest_case_name_[0] = '\0';
     }
 
     if(fmt == NULL)
         return;
 
     va_start(args, fmt);
-    vsnprintf(test_case_name_, sizeof(test_case_name_) - 1, fmt, args);
+    vsnprintf(acutest_case_name_, sizeof(acutest_case_name_) - 1, fmt, args);
     va_end(args);
-    test_case_name_[sizeof(test_case_name_) - 1] = '\0';
+    acutest_case_name_[sizeof(acutest_case_name_) - 1] = '\0';
 
-    if(test_verbose_level_ >= 3) {
-        test_line_indent_(1);
-        test_print_in_color_(TEST_COLOR_DEFAULT_INTENSIVE_, "Case %s:\n", test_case_name_);
-        test_current_already_logged_++;
-        test_case_current_already_logged_++;
+    if(acutest_verbose_level_ >= 3) {
+        acutest_line_indent_(1);
+        acutest_colored_printf_(ACUTEST_COLOR_DEFAULT_INTENSIVE_, "Case %s:\n", acutest_case_name_);
+        acutest_test_already_logged_++;
+        acutest_case_already_logged_++;
     }
 }
 
-void TEST_ATTRIBUTE_(format (printf, 1, 2))
-test_message_(const char* fmt, ...)
+void ACUTEST_ATTRIBUTE_(format (printf, 1, 2))
+acutest_message_(const char* fmt, ...)
 {
     char buffer[TEST_MSG_MAXSIZE];
     char* line_beg;
     char* line_end;
     va_list args;
 
-    if(test_verbose_level_ < 2)
+    if(acutest_verbose_level_ < 2)
         return;
 
     /* We allow extra message only when something is already wrong in the
      * current test. */
-    if(test_current_unit_ == NULL  ||  !test_cond_failed_)
+    if(acutest_current_test_ == NULL  ||  !acutest_cond_failed_)
         return;
 
     va_start(args, fmt);
@@ -769,29 +768,29 @@ test_message_(const char* fmt, ...)
         line_end = strchr(line_beg, '\n');
         if(line_end == NULL)
             break;
-        test_line_indent_(test_case_name_[0] ? 3 : 2);
+        acutest_line_indent_(acutest_case_name_[0] ? 3 : 2);
         printf("%.*s\n", (int)(line_end - line_beg), line_beg);
         line_beg = line_end + 1;
     }
     if(line_beg[0] != '\0') {
-        test_line_indent_(test_case_name_[0] ? 3 : 2);
+        acutest_line_indent_(acutest_case_name_[0] ? 3 : 2);
         printf("%s\n", line_beg);
     }
 }
 
 void
-test_dump_(const char* title, const void* addr, size_t size)
+acutest_dump_(const char* title, const void* addr, size_t size)
 {
     static const size_t BYTES_PER_LINE = 16;
     size_t line_beg;
     size_t truncate = 0;
 
-    if(test_verbose_level_ < 2)
+    if(acutest_verbose_level_ < 2)
         return;
 
     /* We allow extra message only when something is already wrong in the
      * current test. */
-    if(test_current_unit_ == NULL  ||  !test_cond_failed_)
+    if(acutest_current_test_ == NULL  ||  !acutest_cond_failed_)
         return;
 
     if(size > TEST_DUMP_MAXSIZE) {
@@ -799,14 +798,14 @@ test_dump_(const char* title, const void* addr, size_t size)
         size = TEST_DUMP_MAXSIZE;
     }
 
-    test_line_indent_(test_case_name_[0] ? 3 : 2);
+    acutest_line_indent_(acutest_case_name_[0] ? 3 : 2);
     printf((title[strlen(title)-1] == ':') ? "%s\n" : "%s:\n", title);
 
     for(line_beg = 0; line_beg < size; line_beg += BYTES_PER_LINE) {
         size_t line_end = line_beg + BYTES_PER_LINE;
         size_t off;
 
-        test_line_indent_(test_case_name_[0] ? 4 : 3);
+        acutest_line_indent_(acutest_case_name_[0] ? 4 : 3);
         printf("%08lx: ", (unsigned long)line_beg);
         for(off = line_beg; off < line_end; off++) {
             if(off < size)
@@ -828,14 +827,14 @@ test_dump_(const char* title, const void* addr, size_t size)
     }
 
     if(truncate > 0) {
-        test_line_indent_(test_case_name_[0] ? 4 : 3);
+        acutest_line_indent_(acutest_case_name_[0] ? 4 : 3);
         printf("           ... (and more %u bytes)\n", (unsigned) truncate);
     }
 }
 
 /* This is called just before each test */
 static void
-test_init_(const char *test_name)
+acutest_init_(const char *test_name)
 {
 #ifdef TEST_INIT
     TEST_INIT
@@ -848,7 +847,7 @@ test_init_(const char *test_name)
 
 /* This is called after each test */
 static void
-test_fini_(const char *test_name)
+acutest_fini_(const char *test_name)
 {
 #ifdef TEST_FINI
     TEST_FINI
@@ -860,51 +859,51 @@ test_fini_(const char *test_name)
 }
 
 void
-test_abort_(void)
+acutest_abort_(void)
 {
-    if(test_abort_has_jmp_buf_) {
-        longjmp(test_abort_jmp_buf_, 1);
+    if(acutest_abort_has_jmp_buf_) {
+        longjmp(acutest_abort_jmp_buf_, 1);
     } else {
-        if(test_current_unit_ != NULL)
-            test_fini_(test_current_unit_->name);
+        if(acutest_current_test_ != NULL)
+            acutest_fini_(acutest_current_test_->name);
         abort();
     }
 }
 
 static void
-test_list_names_(void)
+acutest_list_names_(void)
 {
-    const struct test_* test;
+    const struct acutest_test_* test;
 
     printf("Unit tests:\n");
-    for(test = &test_list_[0]; test->func != NULL; test++)
+    for(test = &acutest_list_[0]; test->func != NULL; test++)
         printf("  %s\n", test->name);
 }
 
 static void
-test_remember_(int i)
+acutest_remember_(int i)
 {
-    if(test_details_[i].flags & TEST_FLAG_RUN_)
+    if(acutest_test_data_[i].flags & ACUTEST_FLAG_RUN_)
         return;
 
-    test_details_[i].flags |= TEST_FLAG_RUN_;
-    test_count_++;
+    acutest_test_data_[i].flags |= ACUTEST_FLAG_RUN_;
+    acutest_count_++;
 }
 
 static void
-test_set_success_(int i, int success)
+acutest_set_success_(int i, int success)
 {
-    test_details_[i].flags |= success ? TEST_FLAG_SUCCESS_ : TEST_FLAG_FAILURE_;
+    acutest_test_data_[i].flags |= success ? ACUTEST_FLAG_SUCCESS_ : ACUTEST_FLAG_FAILURE_;
 }
 
 static void
-test_set_duration_(int i, double duration)
+acutest_set_duration_(int i, double duration)
 {
-    test_details_[i].duration = duration;
+    acutest_test_data_[i].duration = duration;
 }
 
 static int
-test_name_contains_word_(const char* name, const char* pattern)
+acutest_name_contains_word_(const char* name, const char* pattern)
 {
     static const char word_delim[] = " \t-_/.,:;";
     const char* substr;
@@ -927,15 +926,15 @@ test_name_contains_word_(const char* name, const char* pattern)
 }
 
 static int
-test_lookup_(const char* pattern)
+acutest_lookup_(const char* pattern)
 {
     int i;
     int n = 0;
 
     /* Try exact match. */
-    for(i = 0; i < (int) test_list_size_; i++) {
-        if(strcmp(test_list_[i].name, pattern) == 0) {
-            test_remember_(i);
+    for(i = 0; i < (int) acutest_list_size_; i++) {
+        if(strcmp(acutest_list_[i].name, pattern) == 0) {
+            acutest_remember_(i);
             n++;
             break;
         }
@@ -944,9 +943,9 @@ test_lookup_(const char* pattern)
         return n;
 
     /* Try word match. */
-    for(i = 0; i < (int) test_list_size_; i++) {
-        if(test_name_contains_word_(test_list_[i].name, pattern)) {
-            test_remember_(i);
+    for(i = 0; i < (int) acutest_list_size_; i++) {
+        if(acutest_name_contains_word_(acutest_list_[i].name, pattern)) {
+            acutest_remember_(i);
             n++;
         }
     }
@@ -954,9 +953,9 @@ test_lookup_(const char* pattern)
         return n;
 
     /* Try relaxed match. */
-    for(i = 0; i < (int) test_list_size_; i++) {
-        if(strstr(test_list_[i].name, pattern) != NULL) {
-            test_remember_(i);
+    for(i = 0; i < (int) acutest_list_size_; i++) {
+        if(strstr(acutest_list_[i].name, pattern) != NULL) {
+            acutest_remember_(i);
             n++;
         }
     }
@@ -968,140 +967,140 @@ test_lookup_(const char* pattern)
 /* Called if anything goes bad in Acutest, or if the unit test ends in other
  * way then by normal returning from its function (e.g. exception or some
  * abnormal child process termination). */
-static void TEST_ATTRIBUTE_(format (printf, 1, 2))
-test_error_(const char* fmt, ...)
+static void ACUTEST_ATTRIBUTE_(format (printf, 1, 2))
+acutest_error_(const char* fmt, ...)
 {
-    if(test_verbose_level_ == 0)
+    if(acutest_verbose_level_ == 0)
         return;
 
-    if(test_verbose_level_ >= 2) {
+    if(acutest_verbose_level_ >= 2) {
         va_list args;
 
-        test_line_indent_(1);
-        if(test_verbose_level_ >= 3)
-            test_print_in_color_(TEST_COLOR_RED_INTENSIVE_, "ERROR: ");
+        acutest_line_indent_(1);
+        if(acutest_verbose_level_ >= 3)
+            acutest_colored_printf_(ACUTEST_COLOR_RED_INTENSIVE_, "ERROR: ");
         va_start(args, fmt);
         vprintf(fmt, args);
         va_end(args);
         printf("\n");
     }
 
-    if(test_verbose_level_ >= 3) {
+    if(acutest_verbose_level_ >= 3) {
         printf("\n");
     }
 }
 
 /* Call directly the given test unit function. */
 static int
-test_do_run_(const struct test_* test, int index)
+acutest_do_run_(const struct acutest_test_* test, int index)
 {
     int status = -1;
 
-    test_was_aborted_ = 0;
-    test_current_unit_ = test;
-    test_current_index_ = index;
-    test_current_failures_ = 0;
-    test_current_already_logged_ = 0;
-    test_cond_failed_ = 0;
+    acutest_was_aborted_ = 0;
+    acutest_current_test_ = test;
+    acutest_current_index_ = index;
+    acutest_test_failures_ = 0;
+    acutest_test_already_logged_ = 0;
+    acutest_cond_failed_ = 0;
 
 #ifdef __cplusplus
     try {
 #endif
-        test_init_(test->name);
-        test_begin_test_line_(test);
+        acutest_init_(test->name);
+        acutest_begin_test_line_(test);
 
         /* This is good to do in case the test unit crashes. */
         fflush(stdout);
         fflush(stderr);
 
-        if(!test_worker_) {
-            test_abort_has_jmp_buf_ = 1;
-            if(setjmp(test_abort_jmp_buf_) != 0) {
-                test_was_aborted_ = 1;
+        if(!acutest_worker_) {
+            acutest_abort_has_jmp_buf_ = 1;
+            if(setjmp(acutest_abort_jmp_buf_) != 0) {
+                acutest_was_aborted_ = 1;
                 goto aborted;
             }
         }
 
-        test_timer_get_time_(&test_timer_start_);
+        acutest_timer_get_time_(&acutest_timer_start_);
         test->func();
 aborted:
-        test_abort_has_jmp_buf_ = 0;
-        test_timer_get_time_(&test_timer_end_);
+        acutest_abort_has_jmp_buf_ = 0;
+        acutest_timer_get_time_(&acutest_timer_end_);
 
-        if(test_verbose_level_ >= 3) {
-            test_line_indent_(1);
-            if(test_current_failures_ == 0) {
-                test_print_in_color_(TEST_COLOR_GREEN_INTENSIVE_, "SUCCESS: ");
+        if(acutest_verbose_level_ >= 3) {
+            acutest_line_indent_(1);
+            if(acutest_test_failures_ == 0) {
+                acutest_colored_printf_(ACUTEST_COLOR_GREEN_INTENSIVE_, "SUCCESS: ");
                 printf("All conditions have passed.\n");
 
-                if(test_timer_) {
-                    test_line_indent_(1);
+                if(acutest_timer_) {
+                    acutest_line_indent_(1);
                     printf("Duration: ");
-                    test_timer_print_diff_();
+                    acutest_timer_print_diff_();
                     printf("\n");
                 }
             } else {
-                test_print_in_color_(TEST_COLOR_RED_INTENSIVE_, "FAILED: ");
-                if(!test_was_aborted_) {
+                acutest_colored_printf_(ACUTEST_COLOR_RED_INTENSIVE_, "FAILED: ");
+                if(!acutest_was_aborted_) {
                     printf("%d condition%s %s failed.\n",
-                            test_current_failures_,
-                            (test_current_failures_ == 1) ? "" : "s",
-                            (test_current_failures_ == 1) ? "has" : "have");
+                            acutest_test_failures_,
+                            (acutest_test_failures_ == 1) ? "" : "s",
+                            (acutest_test_failures_ == 1) ? "has" : "have");
                 } else {
                     printf("Aborted.\n");
                 }
             }
             printf("\n");
-        } else if(test_verbose_level_ >= 1 && test_current_failures_ == 0) {
-            test_finish_test_line_(0);
+        } else if(acutest_verbose_level_ >= 1 && acutest_test_failures_ == 0) {
+            acutest_finish_test_line_(0);
         }
 
-        status = (test_current_failures_ == 0) ? 0 : -1;
+        status = (acutest_test_failures_ == 0) ? 0 : -1;
 
 #ifdef __cplusplus
     } catch(std::exception& e) {
         const char* what = e.what();
-        test_check_(0, NULL, 0, "Threw std::exception");
+        acutest_check_(0, NULL, 0, "Threw std::exception");
         if(what != NULL)
-            test_message_("std::exception::what(): %s", what);
+            acutest_message_("std::exception::what(): %s", what);
 
-        if(test_verbose_level_ >= 3) {
-            test_line_indent_(1);
-            test_print_in_color_(TEST_COLOR_RED_INTENSIVE_, "FAILED: ");
+        if(acutest_verbose_level_ >= 3) {
+            acutest_line_indent_(1);
+            acutest_colored_printf_(ACUTEST_COLOR_RED_INTENSIVE_, "FAILED: ");
             printf("C++ exception.\n\n");
         }
     } catch(...) {
-        test_check_(0, NULL, 0, "Threw an exception");
+        acutest_check_(0, NULL, 0, "Threw an exception");
 
-        if(test_verbose_level_ >= 3) {
-            test_line_indent_(1);
-            test_print_in_color_(TEST_COLOR_RED_INTENSIVE_, "FAILED: ");
+        if(acutest_verbose_level_ >= 3) {
+            acutest_line_indent_(1);
+            acutest_colored_printf_(ACUTEST_COLOR_RED_INTENSIVE_, "FAILED: ");
             printf("C++ exception.\n\n");
         }
     }
 #endif
 
-    test_fini_(test->name);
-    test_case_(NULL);
-    test_current_unit_ = NULL;
+    acutest_fini_(test->name);
+    acutest_case_(NULL);
+    acutest_current_test_ = NULL;
 
     return status;
 }
 
 /* Trigger the unit test. If possible (and not suppressed) it starts a child
- * process who calls test_do_run_(), otherwise it calls test_do_run_()
+ * process who calls acutest_do_run_(), otherwise it calls acutest_do_run_()
  * directly. */
 static void
-test_run_(const struct test_* test, int index, int master_index)
+acutest_run_(const struct acutest_test_* test, int index, int master_index)
 {
     int failed = 1;
-    test_timer_type_ start, end;
+    acutest_timer_type_ start, end;
 
-    test_current_unit_ = test;
-    test_current_already_logged_ = 0;
-    test_timer_get_time_(&start);
+    acutest_current_test_ = test;
+    acutest_test_already_logged_ = 0;
+    acutest_timer_get_time_(&start);
 
-    if(!test_no_exec_) {
+    if(!acutest_no_exec_) {
 
 #if defined(ACUTEST_UNIX_)
 
@@ -1114,13 +1113,13 @@ test_run_(const struct test_* test, int index, int master_index)
 
         pid = fork();
         if(pid == (pid_t)-1) {
-            test_error_("Cannot fork. %s [%d]", strerror(errno), errno);
+            acutest_error_("Cannot fork. %s [%d]", strerror(errno), errno);
             failed = 1;
         } else if(pid == 0) {
             /* Child: Do the test. */
-            test_worker_ = 1;
+            acutest_worker_ = 1;
             failed = (test_do_run_(test, index) != 0);
-            test_exit_(failed ? 1 : 0);
+            acutest_exit_(failed ? 1 : 0);
         } else {
             /* Parent: Wait until child terminates and analyze its exit code. */
             waitpid(pid, &exit_code, 0);
@@ -1128,7 +1127,7 @@ test_run_(const struct test_* test, int index, int master_index)
                 switch(WEXITSTATUS(exit_code)) {
                     case 0:   failed = 0; break;   /* test has passed. */
                     case 1:   /* noop */ break;    /* "normal" failure. */
-                    default:  test_error_("Unexpected exit code [%d]", WEXITSTATUS(exit_code));
+                    default:  acutest_error_("Unexpected exit code [%d]", WEXITSTATUS(exit_code));
                 }
             } else if(WIFSIGNALED(exit_code)) {
                 char tmp[32];
@@ -1144,9 +1143,9 @@ test_run_(const struct test_* test, int index, int master_index)
                     case SIGTERM: signame = "SIGTERM"; break;
                     default:      sprintf(tmp, "signal %d", WTERMSIG(exit_code)); signame = tmp; break;
                 }
-                test_error_("Test interrupted by %s.", signame);
+                acutest_error_("Test interrupted by %s.", signame);
             } else {
-                test_error_("Test ended in an unexpected way [%d].", exit_code);
+                acutest_error_("Test ended in an unexpected way [%d].", exit_code);
             }
         }
 
@@ -1161,9 +1160,9 @@ test_run_(const struct test_* test, int index, int master_index)
          * through a command line arguments. */
         _snprintf(buffer, sizeof(buffer)-1,
                  "%s --worker=%d %s --no-exec --no-summary %s --verbose=%d --color=%s -- \"%s\"",
-                 test_argv0_, index, test_timer_ ? "--time" : "",
-                 test_tap_ ? "--tap" : "", test_verbose_level_,
-                 test_colorize_ ? "always" : "never",
+                 acutest_argv0_, index, acutest_timer_ ? "--time" : "",
+                 acutest_tap_ ? "--tap" : "", acutest_verbose_level_,
+                 acutest_colorize_ ? "always" : "never",
                  test->name);
         memset(&startupInfo, 0, sizeof(startupInfo));
         startupInfo.cb = sizeof(STARTUPINFO);
@@ -1175,47 +1174,47 @@ test_run_(const struct test_* test, int index, int master_index)
             failed = (exitCode != 0);
             if(exitCode > 1) {
                 switch(exitCode) {
-                    case 3:             test_error_("Aborted."); break;
-                    case 0xC0000005:    test_error_("Access violation."); break;
-                    default:            test_error_("Test ended in an unexpected way [%lu].", exitCode); break;
+                    case 3:             acutest_error_("Aborted."); break;
+                    case 0xC0000005:    acutest_error_("Access violation."); break;
+                    default:            acutest_error_("Test ended in an unexpected way [%lu].", exitCode); break;
                 }
             }
         } else {
-            test_error_("Cannot create unit test subprocess [%ld].", GetLastError());
+            acutest_error_("Cannot create unit test subprocess [%ld].", GetLastError());
             failed = 1;
         }
 
 #else
 
         /* A platform where we don't know how to run child process. */
-        failed = (test_do_run_(test, index) != 0);
+        failed = (acutest_do_run_(test, index) != 0);
 
 #endif
 
     } else {
         /* Child processes suppressed through --no-exec. */
-        failed = (test_do_run_(test, index) != 0);
+        failed = (acutest_do_run_(test, index) != 0);
     }
-    test_timer_get_time_(&end);
+    acutest_timer_get_time_(&end);
 
-    test_current_unit_ = NULL;
+    acutest_current_test_ = NULL;
 
-    test_stat_run_units_++;
+    acutest_stat_run_units_++;
     if(failed)
-        test_stat_failed_units_++;
+        acutest_stat_failed_units_++;
 
-    test_set_success_(master_index, !failed);
-    test_set_duration_(master_index, test_timer_diff_(start, end));
+    acutest_set_success_(master_index, !failed);
+    acutest_set_duration_(master_index, acutest_timer_diff_(start, end));
 }
 
 #if defined(ACUTEST_WIN_)
 /* Callback for SEH events. */
 static LONG CALLBACK
-test_seh_exception_filter_(EXCEPTION_POINTERS *ptrs)
+acutest_seh_exception_filter_(EXCEPTION_POINTERS *ptrs)
 {
-    test_check_(0, NULL, 0, "Unhandled SEH exception");
-    test_message_("Exception code:    0x%08lx", ptrs->ExceptionRecord->ExceptionCode);
-    test_message_("Exception address: 0x%p", ptrs->ExceptionRecord->ExceptionAddress);
+    acutest_check_(0, NULL, 0, "Unhandled SEH exception");
+    acutest_message_("Exception code:    0x%08lx", ptrs->ExceptionRecord->ExceptionCode);
+    acutest_message_("Exception address: 0x%p", ptrs->ExceptionRecord->ExceptionAddress);
 
     fflush(stdout);
     fflush(stderr);
@@ -1225,27 +1224,27 @@ test_seh_exception_filter_(EXCEPTION_POINTERS *ptrs)
 #endif
 
 
-#define TEST_CMDLINE_OPTFLAG_OPTIONALARG_   0x0001
-#define TEST_CMDLINE_OPTFLAG_REQUIREDARG_   0x0002
+#define ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_    0x0001
+#define ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_    0x0002
 
-#define TEST_CMDLINE_OPTID_NONE_            0
-#define TEST_CMDLINE_OPTID_UNKNOWN_         (-0x7fffffff + 0)
-#define TEST_CMDLINE_OPTID_MISSINGARG_      (-0x7fffffff + 1)
-#define TEST_CMDLINE_OPTID_BOGUSARG_        (-0x7fffffff + 2)
+#define ACUTEST_CMDLINE_OPTID_NONE_             0
+#define ACUTEST_CMDLINE_OPTID_UNKNOWN_          (-0x7fffffff + 0)
+#define ACUTEST_CMDLINE_OPTID_MISSINGARG_       (-0x7fffffff + 1)
+#define ACUTEST_CMDLINE_OPTID_BOGUSARG_         (-0x7fffffff + 2)
 
-typedef struct TEST_CMDLINE_OPTION_ {
+typedef struct acutest_test_CMDLINE_OPTION_ {
     char shortname;
     const char* longname;
     int id;
     unsigned flags;
-} TEST_CMDLINE_OPTION_;
+} ACUTEST_CMDLINE_OPTION_;
 
 static int
-test_cmdline_handle_short_opt_group_(const TEST_CMDLINE_OPTION_* options,
+acutest_cmdline_handle_short_opt_group_(const ACUTEST_CMDLINE_OPTION_* options,
                     const char* arggroup,
                     int (*callback)(int /*optval*/, const char* /*arg*/))
 {
-    const TEST_CMDLINE_OPTION_* opt;
+    const ACUTEST_CMDLINE_OPTION_* opt;
     int i;
     int ret = 0;
 
@@ -1255,7 +1254,7 @@ test_cmdline_handle_short_opt_group_(const TEST_CMDLINE_OPTION_* options,
                 break;
         }
 
-        if(opt->id != 0  &&  !(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG_)) {
+        if(opt->id != 0  &&  !(opt->flags & ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_)) {
             ret = callback(opt->id, NULL);
         } else {
             /* Unknown option. */
@@ -1263,7 +1262,7 @@ test_cmdline_handle_short_opt_group_(const TEST_CMDLINE_OPTION_* options,
             badoptname[0] = '-';
             badoptname[1] = arggroup[i];
             badoptname[2] = '\0';
-            ret = callback((opt->id != 0 ? TEST_CMDLINE_OPTID_MISSINGARG_ : TEST_CMDLINE_OPTID_UNKNOWN_),
+            ret = callback((opt->id != 0 ? ACUTEST_CMDLINE_OPTID_MISSINGARG_ : ACUTEST_CMDLINE_OPTID_UNKNOWN_),
                             badoptname);
         }
 
@@ -1274,31 +1273,31 @@ test_cmdline_handle_short_opt_group_(const TEST_CMDLINE_OPTION_* options,
     return ret;
 }
 
-#define TEST_CMDLINE_AUXBUF_SIZE_  32
+#define ACUTEST_CMDLINE_AUXBUF_SIZE_  32
 
 static int
-test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
-                    int (*callback)(int /*optval*/, const char* /*arg*/))
+acutest_cmdline_read_(const ACUTEST_CMDLINE_OPTION_* options, int argc, char** argv,
+                      int (*callback)(int /*optval*/, const char* /*arg*/))
 {
 
-    const TEST_CMDLINE_OPTION_* opt;
-    char auxbuf[TEST_CMDLINE_AUXBUF_SIZE_+1];
+    const ACUTEST_CMDLINE_OPTION_* opt;
+    char auxbuf[ACUTEST_CMDLINE_AUXBUF_SIZE_+1];
     int after_doubledash = 0;
     int i = 1;
     int ret = 0;
 
-    auxbuf[TEST_CMDLINE_AUXBUF_SIZE_] = '\0';
+    auxbuf[ACUTEST_CMDLINE_AUXBUF_SIZE_] = '\0';
 
     while(i < argc) {
         if(after_doubledash  ||  strcmp(argv[i], "-") == 0) {
             /* Non-option argument. */
-            ret = callback(TEST_CMDLINE_OPTID_NONE_, argv[i]);
+            ret = callback(ACUTEST_CMDLINE_OPTID_NONE_, argv[i]);
         } else if(strcmp(argv[i], "--") == 0) {
             /* End of options. All the remaining members are non-option arguments. */
             after_doubledash = 1;
         } else if(argv[i][0] != '-') {
             /* Non-option argument. */
-            ret = callback(TEST_CMDLINE_OPTID_NONE_, argv[i]);
+            ret = callback(ACUTEST_CMDLINE_OPTID_NONE_, argv[i]);
         } else {
             for(opt = options; opt->id != 0; opt++) {
                 if(opt->longname != NULL  &&  strncmp(argv[i], "--", 2) == 0) {
@@ -1307,18 +1306,18 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
                         /* Regular long option. */
                         if(argv[i][2+len] == '\0') {
                             /* with no argument provided. */
-                            if(!(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG_))
+                            if(!(opt->flags & ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_))
                                 ret = callback(opt->id, NULL);
                             else
-                                ret = callback(TEST_CMDLINE_OPTID_MISSINGARG_, argv[i]);
+                                ret = callback(ACUTEST_CMDLINE_OPTID_MISSINGARG_, argv[i]);
                             break;
                         } else if(argv[i][2+len] == '=') {
                             /* with an argument provided. */
-                            if(opt->flags & (TEST_CMDLINE_OPTFLAG_OPTIONALARG_ | TEST_CMDLINE_OPTFLAG_REQUIREDARG_)) {
+                            if(opt->flags & (ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ | ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_)) {
                                 ret = callback(opt->id, argv[i]+2+len+1);
                             } else {
                                 sprintf(auxbuf, "--%s", opt->longname);
-                                ret = callback(TEST_CMDLINE_OPTID_BOGUSARG_, auxbuf);
+                                ret = callback(ACUTEST_CMDLINE_OPTID_BOGUSARG_, auxbuf);
                             }
                             break;
                         } else {
@@ -1328,13 +1327,13 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
                 } else if(opt->shortname != '\0'  &&  argv[i][0] == '-') {
                     if(argv[i][1] == opt->shortname) {
                         /* Regular short option. */
-                        if(opt->flags & TEST_CMDLINE_OPTFLAG_REQUIREDARG_) {
+                        if(opt->flags & ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_) {
                             if(argv[i][2] != '\0')
                                 ret = callback(opt->id, argv[i]+2);
                             else if(i+1 < argc)
                                 ret = callback(opt->id, argv[++i]);
                             else
-                                ret = callback(TEST_CMDLINE_OPTID_MISSINGARG_, argv[i]);
+                                ret = callback(ACUTEST_CMDLINE_OPTID_MISSINGARG_, argv[i]);
                             break;
                         } else {
                             ret = callback(opt->id, NULL);
@@ -1342,7 +1341,7 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
                             /* There might be more (argument-less) short options
                              * grouped together. */
                             if(ret == 0  &&  argv[i][2] != '\0')
-                                ret = test_cmdline_handle_short_opt_group_(options, argv[i]+2, callback);
+                                ret = acutest_cmdline_handle_short_opt_group_(options, argv[i]+2, callback);
                             break;
                         }
                     }
@@ -1352,7 +1351,7 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
             if(opt->id == 0) {  /* still not handled? */
                 if(argv[i][0] != '-') {
                     /* Non-option argument. */
-                    ret = callback(TEST_CMDLINE_OPTID_NONE_, argv[i]);
+                    ret = callback(ACUTEST_CMDLINE_OPTID_NONE_, argv[i]);
                 } else {
                     /* Unknown option. */
                     char* badoptname = argv[i];
@@ -1362,15 +1361,15 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
                         char* assignment = strchr(badoptname, '=');
                         if(assignment != NULL) {
                             size_t len = assignment - badoptname;
-                            if(len > TEST_CMDLINE_AUXBUF_SIZE_)
-                                len = TEST_CMDLINE_AUXBUF_SIZE_;
+                            if(len > ACUTEST_CMDLINE_AUXBUF_SIZE_)
+                                len = ACUTEST_CMDLINE_AUXBUF_SIZE_;
                             strncpy(auxbuf, badoptname, len);
                             auxbuf[len] = '\0';
                             badoptname = auxbuf;
                         }
                     }
 
-                    ret = callback(TEST_CMDLINE_OPTID_UNKNOWN_, badoptname);
+                    ret = callback(ACUTEST_CMDLINE_OPTID_UNKNOWN_, badoptname);
                 }
             }
         }
@@ -1384,9 +1383,9 @@ test_cmdline_read_(const TEST_CMDLINE_OPTION_* options, int argc, char** argv,
 }
 
 static void
-test_help_(void)
+acutest_help_(void)
 {
-    printf("Usage: %s [options] [test...]\n", test_argv0_);
+    printf("Usage: %s [options] [test...]\n", acutest_argv0_);
     printf("\n");
     printf("Run the specified unit tests; or if the option '--skip' is used, run all\n");
     printf("tests in the suite but those listed.  By default, if no tests are specified\n");
@@ -1421,158 +1420,158 @@ test_help_(void)
     printf("      --no-color        Same as --color=never\n");
     printf("  -h, --help            Display this help and exit\n");
 
-    if(test_list_size_ < 16) {
+    if(acutest_list_size_ < 16) {
         printf("\n");
-        test_list_names_();
+        acutest_list_names_();
     }
 }
 
-static const TEST_CMDLINE_OPTION_ test_cmdline_options_[] = {
+static const ACUTEST_CMDLINE_OPTION_ acutest_cmdline_options_[] = {
     { 's',  "skip",         's', 0 },
-    {  0,   "exec",         'e', TEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
+    {  0,   "exec",         'e', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
     { 'E',  "no-exec",      'E', 0 },
 #if defined ACUTEST_WIN_
     { 't',  "time",         't', 0 },
     {  0,   "timer",        't', 0 },   /* kept for compatibility */
 #elif defined ACUTEST_HAS_POSIX_TIMER_
-    { 't',  "time",         't', TEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
-    {  0,   "timer",        't', TEST_CMDLINE_OPTFLAG_OPTIONALARG_ },  /* kept for compatibility */
+    { 't',  "time",         't', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
+    {  0,   "timer",        't', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },  /* kept for compatibility */
 #endif
     {  0,   "no-summary",   'S', 0 },
     {  0,   "tap",          'T', 0 },
     { 'l',  "list",         'l', 0 },
-    { 'v',  "verbose",      'v', TEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
+    { 'v',  "verbose",      'v', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
     { 'q',  "quiet",        'q', 0 },
-    {  0,   "color",        'c', TEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
+    {  0,   "color",        'c', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
     {  0,   "no-color",     'C', 0 },
     { 'h',  "help",         'h', 0 },
-    {  0,   "worker",       'w', TEST_CMDLINE_OPTFLAG_REQUIREDARG_ },  /* internal */
-    { 'x',  "xml-output",   'x', TEST_CMDLINE_OPTFLAG_REQUIREDARG_ },
+    {  0,   "worker",       'w', ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_ },  /* internal */
+    { 'x',  "xml-output",   'x', ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_ },
     {  0,   NULL,            0,  0 }
 };
 
 static int
-test_cmdline_callback_(int id, const char* arg)
+acutest_cmdline_callback_(int id, const char* arg)
 {
     switch(id) {
         case 's':
-            test_skip_mode_ = 1;
+            acutest_skip_mode_ = 1;
             break;
 
         case 'e':
             if(arg == NULL || strcmp(arg, "always") == 0) {
-                test_no_exec_ = 0;
+                acutest_no_exec_ = 0;
             } else if(strcmp(arg, "never") == 0) {
-                test_no_exec_ = 1;
+                acutest_no_exec_ = 1;
             } else if(strcmp(arg, "auto") == 0) {
                 /*noop*/
             } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --exec.\n", test_argv0_, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-                test_exit_(2);
+                fprintf(stderr, "%s: Unrecognized argument '%s' for option --exec.\n", acutest_argv0_, arg);
+                fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+                acutest_exit_(2);
             }
             break;
 
         case 'E':
-            test_no_exec_ = 1;
+            acutest_no_exec_ = 1;
             break;
 
         case 't':
 #if defined ACUTEST_WIN_  ||  defined ACUTEST_HAS_POSIX_TIMER_
             if(arg == NULL || strcmp(arg, "real") == 0) {
-                test_timer_ = 1;
+                acutest_timer_ = 1;
     #ifndef ACUTEST_WIN_
             } else if(strcmp(arg, "cpu") == 0) {
-                test_timer_ = 2;
+                acutest_timer_ = 2;
     #endif
             } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --time.\n", test_argv0_, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-                test_exit_(2);
+                fprintf(stderr, "%s: Unrecognized argument '%s' for option --time.\n", acutest_argv0_, arg);
+                fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+                acutest_exit_(2);
             }
 #endif
             break;
 
         case 'S':
-            test_no_summary_ = 1;
+            acutest_no_summary_ = 1;
             break;
 
         case 'T':
-            test_tap_ = 1;
+            acutest_tap_ = 1;
             break;
 
         case 'l':
-            test_list_names_();
-            test_exit_(0);
+            acutest_list_names_();
+            acutest_exit_(0);
             break;
 
         case 'v':
-            test_verbose_level_ = (arg != NULL ? atoi(arg) : test_verbose_level_+1);
+            acutest_verbose_level_ = (arg != NULL ? atoi(arg) : acutest_verbose_level_+1);
             break;
 
         case 'q':
-            test_verbose_level_ = 0;
+            acutest_verbose_level_ = 0;
             break;
 
         case 'c':
             if(arg == NULL || strcmp(arg, "always") == 0) {
-                test_colorize_ = 1;
+                acutest_colorize_ = 1;
             } else if(strcmp(arg, "never") == 0) {
-                test_colorize_ = 0;
+                acutest_colorize_ = 0;
             } else if(strcmp(arg, "auto") == 0) {
                 /*noop*/
             } else {
-                fprintf(stderr, "%s: Unrecognized argument '%s' for option --color.\n", test_argv0_, arg);
-                fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-                test_exit_(2);
+                fprintf(stderr, "%s: Unrecognized argument '%s' for option --color.\n", acutest_argv0_, arg);
+                fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+                acutest_exit_(2);
             }
             break;
 
         case 'C':
-            test_colorize_ = 0;
+            acutest_colorize_ = 0;
             break;
 
         case 'h':
-            test_help_();
-            test_exit_(0);
+            acutest_help_();
+            acutest_exit_(0);
             break;
 
         case 'w':
-            test_worker_ = 1;
-            test_worker_index_ = atoi(arg);
+            acutest_worker_ = 1;
+            acutest_worker_index_ = atoi(arg);
             break;
         case 'x':
-            test_xml_output_ = fopen(arg, "w");
-            if (!test_xml_output_) {
+            acutest_xml_output_ = fopen(arg, "w");
+            if (!acutest_xml_output_) {
                 fprintf(stderr, "Unable to open '%s': %s\n", arg, strerror(errno));
-                test_exit_(2);
+                acutest_exit_(2);
             }
             break;
 
         case 0:
-            if(test_lookup_(arg) == 0) {
-                fprintf(stderr, "%s: Unrecognized unit test '%s'\n", test_argv0_, arg);
-                fprintf(stderr, "Try '%s --list' for list of unit tests.\n", test_argv0_);
-                test_exit_(2);
+            if(acutest_lookup_(arg) == 0) {
+                fprintf(stderr, "%s: Unrecognized unit test '%s'\n", acutest_argv0_, arg);
+                fprintf(stderr, "Try '%s --list' for list of unit tests.\n", acutest_argv0_);
+                acutest_exit_(2);
             }
             break;
 
-        case TEST_CMDLINE_OPTID_UNKNOWN_:
+        case ACUTEST_CMDLINE_OPTID_UNKNOWN_:
             fprintf(stderr, "Unrecognized command line option '%s'.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-            test_exit_(2);
+            fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+            acutest_exit_(2);
             break;
 
-        case TEST_CMDLINE_OPTID_MISSINGARG_:
+        case ACUTEST_CMDLINE_OPTID_MISSINGARG_:
             fprintf(stderr, "The command line option '%s' requires an argument.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-            test_exit_(2);
+            fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+            acutest_exit_(2);
             break;
 
-        case TEST_CMDLINE_OPTID_BOGUSARG_:
+        case ACUTEST_CMDLINE_OPTID_BOGUSARG_:
             fprintf(stderr, "The command line option '%s' does not expect an argument.\n", arg);
-            fprintf(stderr, "Try '%s --help' for more information.\n", test_argv0_);
-            test_exit_(2);
+            fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+            acutest_exit_(2);
             break;
     }
 
@@ -1582,7 +1581,7 @@ test_cmdline_callback_(int id, const char* arg)
 
 #ifdef ACUTEST_LINUX_
 static int
-test_is_tracer_present_(void)
+acutest_is_tracer_present_(void)
 {
     /* Must be large enough so the line 'TracerPid: ${PID}' can fit in. */
     static const int OVERLAP = 32;
@@ -1634,122 +1633,123 @@ int
 main(int argc, char** argv)
 {
     int i;
-    test_argv0_ = argv[0];
+
+    acutest_argv0_ = argv[0];
 
 #if defined ACUTEST_UNIX_
-    test_colorize_ = isatty(STDOUT_FILENO);
+    acutest_colorize_ = isatty(STDOUT_FILENO);
 #elif defined ACUTEST_WIN_
  #if defined _BORLANDC_
-    test_colorize_ = isatty(_fileno(stdout));
+    acutest_colorize_ = isatty(_fileno(stdout));
  #else
-    test_colorize_ = _isatty(_fileno(stdout));
+    acutest_colorize_ = _isatty(_fileno(stdout));
  #endif
 #else
-    test_colorize_ = 0;
+    acutest_colorize_ = 0;
 #endif
 
     /* Count all test units */
-    test_list_size_ = 0;
-    for(i = 0; test_list_[i].func != NULL; i++)
-        test_list_size_++;
+    acutest_list_size_ = 0;
+    for(i = 0; acutest_list_[i].func != NULL; i++)
+        acutest_list_size_++;
 
-    test_details_ = (struct test_detail_*)calloc(test_list_size_, sizeof(struct test_detail_));
-    if(test_details_ == NULL) {
+    acutest_test_data_ = (struct acutest_test_data_*)calloc(acutest_list_size_, sizeof(struct acutest_test_data_));
+    if(acutest_test_data_ == NULL) {
         fprintf(stderr, "Out of memory.\n");
-        test_exit_(2);
+        acutest_exit_(2);
     }
 
     /* Parse options */
-    test_cmdline_read_(test_cmdline_options_, argc, argv, test_cmdline_callback_);
+    acutest_cmdline_read_(acutest_cmdline_options_, argc, argv, acutest_cmdline_callback_);
 
     /* Initialize the proper timer. */
-    test_timer_init_();
+    acutest_timer_init_();
 
 #if defined(ACUTEST_WIN_)
-    SetUnhandledExceptionFilter(test_seh_exception_filter_);
+    SetUnhandledExceptionFilter(acutest_seh_exception_filter_);
 #ifdef _MSC_VER
     _set_abort_behavior(0, _WRITE_ABORT_MSG);
 #endif
 #endif
 
     /* By default, we want to run all tests. */
-    if(test_count_ == 0) {
-        for(i = 0; test_list_[i].func != NULL; i++)
-            test_remember_(i);
+    if(acutest_count_ == 0) {
+        for(i = 0; acutest_list_[i].func != NULL; i++)
+            acutest_remember_(i);
     }
 
     /* Guess whether we want to run unit tests as child processes. */
-    if(test_no_exec_ < 0) {
-        test_no_exec_ = 0;
+    if(acutest_no_exec_ < 0) {
+        acutest_no_exec_ = 0;
 
-        if(test_count_ <= 1) {
-            test_no_exec_ = 1;
+        if(acutest_count_ <= 1) {
+            acutest_no_exec_ = 1;
         } else {
 #ifdef ACUTEST_WIN_
             if(IsDebuggerPresent())
-                test_no_exec_ = 1;
+                acutest_no_exec_ = 1;
 #endif
 #ifdef ACUTEST_LINUX_
-            if(test_is_tracer_present_())
-                test_no_exec_ = 1;
+            if(acutest_is_tracer_present_())
+                acutest_no_exec_ = 1;
 #endif
 #ifdef RUNNING_ON_VALGRIND
-            /* RUNNING_ON_VALGRIND is provided by valgrind.h */
+            /* RUNNING_ON_VALGRIND is provided by optionally included <valgrind.h> */
             if(RUNNING_ON_VALGRIND)
-                test_no_exec_ = 1;
+                acutest_no_exec_ = 1;
 #endif
         }
     }
 
-    if(test_tap_) {
+    if(acutest_tap_) {
         /* TAP requires we know test result ("ok", "not ok") before we output
          * anything about the test, and this gets problematic for larger verbose
          * levels. */
-        if(test_verbose_level_ > 2)
-            test_verbose_level_ = 2;
+        if(acutest_verbose_level_ > 2)
+            acutest_verbose_level_ = 2;
 
         /* TAP harness should provide some summary. */
-        test_no_summary_ = 1;
+        acutest_no_summary_ = 1;
 
-        if(!test_worker_)
-            printf("1..%d\n", (int) test_count_);
+        if(!acutest_worker_)
+            printf("1..%d\n", (int) acutest_count_);
     }
 
-    int index = test_worker_index_;
-    for(i = 0; test_list_[i].func != NULL; i++) {
-        int run = (test_details_[i].flags & TEST_FLAG_RUN_);
-        if (test_skip_mode_) /* Run all tests except those listed. */
+    int index = acutest_worker_index_;
+    for(i = 0; acutest_list_[i].func != NULL; i++) {
+        int run = (acutest_test_data_[i].flags & ACUTEST_FLAG_RUN_);
+        if (acutest_skip_mode_) /* Run all tests except those listed. */
             run = !run;
         if(run)
-            test_run_(&test_list_[i], index++, i);
+            acutest_run_(&acutest_list_[i], index++, i);
     }
 
     /* Write a summary */
-    if(!test_no_summary_ && test_verbose_level_ >= 1) {
-        if(test_verbose_level_ >= 3) {
-            test_print_in_color_(TEST_COLOR_DEFAULT_INTENSIVE_, "Summary:\n");
+    if(!acutest_no_summary_ && acutest_verbose_level_ >= 1) {
+        if(acutest_verbose_level_ >= 3) {
+            acutest_colored_printf_(ACUTEST_COLOR_DEFAULT_INTENSIVE_, "Summary:\n");
 
-            printf("  Count of all unit tests:     %4d\n", (int) test_list_size_);
-            printf("  Count of run unit tests:     %4d\n", test_stat_run_units_);
-            printf("  Count of failed unit tests:  %4d\n", test_stat_failed_units_);
-            printf("  Count of skipped unit tests: %4d\n", (int) test_list_size_ - test_stat_run_units_);
+            printf("  Count of all unit tests:     %4d\n", (int) acutest_list_size_);
+            printf("  Count of run unit tests:     %4d\n", acutest_stat_run_units_);
+            printf("  Count of failed unit tests:  %4d\n", acutest_stat_failed_units_);
+            printf("  Count of skipped unit tests: %4d\n", (int) acutest_list_size_ - acutest_stat_run_units_);
         }
 
-        if(test_stat_failed_units_ == 0) {
-            test_print_in_color_(TEST_COLOR_GREEN_INTENSIVE_, "SUCCESS:");
+        if(acutest_stat_failed_units_ == 0) {
+            acutest_colored_printf_(ACUTEST_COLOR_GREEN_INTENSIVE_, "SUCCESS:");
             printf(" All unit tests have passed.\n");
         } else {
-            test_print_in_color_(TEST_COLOR_RED_INTENSIVE_, "FAILED:");
+            acutest_colored_printf_(ACUTEST_COLOR_RED_INTENSIVE_, "FAILED:");
             printf(" %d of %d unit tests %s failed.\n",
-                    test_stat_failed_units_, test_stat_run_units_,
-                    (test_stat_failed_units_ == 1) ? "has" : "have");
+                    acutest_stat_failed_units_, acutest_stat_run_units_,
+                    (acutest_stat_failed_units_ == 1) ? "has" : "have");
         }
 
-        if(test_verbose_level_ >= 3)
+        if(acutest_verbose_level_ >= 3)
             printf("\n");
     }
 
-    if (test_xml_output_) {
+    if (acutest_xml_output_) {
 #if defined ACUTEST_UNIX_
         char *suite_name = basename(argv[0]);
 #elif defined ACUTEST_WIN_
@@ -1758,26 +1758,26 @@ main(int argc, char** argv)
 #else
         const char *suite_name = argv[0];
 #endif
-        fprintf(test_xml_output_, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        fprintf(test_xml_output_, "<testsuite name=\"%s\" tests=\"%d\" errors=\"%d\" failures=\"%d\" skip=\"%d\">\n",
-            suite_name, (int)test_list_size_, test_stat_failed_units_, test_stat_failed_units_,
-            (int)test_list_size_ - test_stat_run_units_);
-        for(i = 0; test_list_[i].func != NULL; i++) {
-            struct test_detail_ *details = &test_details_[i];
-            fprintf(test_xml_output_, "  <testcase name=\"%s\" time=\"%.2f\">\n", test_list_[i].name, details->duration);
-            if (details->flags & TEST_FLAG_FAILURE_)
-                fprintf(test_xml_output_, "    <failure />\n");
-            if (!(details->flags & TEST_FLAG_FAILURE_) && !(details->flags & TEST_FLAG_SUCCESS_))
-                fprintf(test_xml_output_, "    <skipped />\n");
-            fprintf(test_xml_output_, "  </testcase>\n");
+        fprintf(acutest_xml_output_, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        fprintf(acutest_xml_output_, "<testsuite name=\"%s\" tests=\"%d\" errors=\"%d\" failures=\"%d\" skip=\"%d\">\n",
+            suite_name, (int)acutest_list_size_, acutest_stat_failed_units_, acutest_stat_failed_units_,
+            (int)acutest_list_size_ - acutest_stat_run_units_);
+        for(i = 0; acutest_list_[i].func != NULL; i++) {
+            struct acutest_test_data_ *details = &acutest_test_data_[i];
+            fprintf(acutest_xml_output_, "  <testcase name=\"%s\" time=\"%.2f\">\n", acutest_list_[i].name, details->duration);
+            if (details->flags & ACUTEST_FLAG_FAILURE_)
+                fprintf(acutest_xml_output_, "    <failure />\n");
+            if (!(details->flags & ACUTEST_FLAG_FAILURE_) && !(details->flags & ACUTEST_FLAG_SUCCESS_))
+                fprintf(acutest_xml_output_, "    <skipped />\n");
+            fprintf(acutest_xml_output_, "  </testcase>\n");
         }
-        fprintf(test_xml_output_, "</testsuite>\n");
-        fclose(test_xml_output_);
+        fprintf(acutest_xml_output_, "</testsuite>\n");
+        fclose(acutest_xml_output_);
     }
 
-    test_cleanup_();
+    acutest_cleanup_();
 
-    return (test_stat_failed_units_ == 0) ? 0 : 1;
+    return (acutest_stat_failed_units_ == 0) ? 0 : 1;
 }
 
 


### PR DESCRIPTION
Make a clearer distinction between the public API and the implementation
so that public staf begins "TEST_" and all internal stuff begins with
the prefix "ACUTEST_" or "acutest_".