### PR TITLE
Macos debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ and its core depends only on few standard C library functions.
 * Acutest installs a SEH filter to print out uncaught SEH exceptions.
 * User can measure test execution times with `--time`.
 
+**macOS specific features:**
+* If a debugger is detected, the default execution of tests as child processes
+  is suppressed in order to make the debugging easier.
+
 Any C/C++ module implementing one or more unit tests and including `acutest.h`,
 can be built as a standalone program. We call the resulted binary as a "test
 suite" for purposes of this document. The suite is then executed to run the

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -306,6 +306,15 @@
     #include <io.h>
 #endif
 
+#if defined(__APPLE__)
+    #define ACUTEST_MACOS_
+    #include <assert.h>
+    #include <stdbool.h>
+    #include <sys/types.h>
+    #include <unistd.h>
+    #include <sys/sysctl.h>
+#endif
+
 #ifdef __cplusplus
     #include <exception>
 #endif
@@ -1629,6 +1638,36 @@ acutest_is_tracer_present_(void)
 }
 #endif
 
+#ifdef ACUTEST_MACOS_
+static bool
+AmIBeingDebugged(void)
+{
+    int junk;
+    int mib[4];
+    struct kinfo_proc info;
+    size_t size;
+
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    info.kp_proc.p_flag = 0;
+
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+
+    // Call sysctl.
+    size = sizeof(info);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    assert(junk == 0);
+
+    // We're being debugged if the P_TRACED flag is set.
+    return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
+}
+#endif
+
 int
 main(int argc, char** argv)
 {
@@ -1691,6 +1730,10 @@ main(int argc, char** argv)
 #endif
 #ifdef ACUTEST_LINUX_
             if(acutest_is_tracer_present_())
+                acutest_no_exec_ = 1;
+#endif
+#ifdef ACUTEST_MACOS_
+            if(AmIBeingDebugged())
                 acutest_no_exec_ = 1;
 #endif
 #ifdef RUNNING_ON_VALGRIND

--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1640,7 +1640,7 @@ acutest_is_tracer_present_(void)
 
 #ifdef ACUTEST_MACOS_
 static bool
-AmIBeingDebugged(void)
+acutest_AmIBeingDebugged(void)
 {
     int junk;
     int mib[4];
@@ -1733,7 +1733,7 @@ main(int argc, char** argv)
                 acutest_no_exec_ = 1;
 #endif
 #ifdef ACUTEST_MACOS_
-            if(AmIBeingDebugged())
+            if(acutest_AmIBeingDebugged())
                 acutest_no_exec_ = 1;
 #endif
 #ifdef RUNNING_ON_VALGRIND


### PR DESCRIPTION
Since debugger detection is already present on both Linux and Windows, I took the liberty to add support for macOS as well. The implementation is based upon [Detecting the Debugger](https://developer.apple.com/library/archive/qa/qa1361/_index.html) provided by [Apple](http://apple.com).

Closes #36 