### PR TITLE
Fix compilation error when using `#define TEST_NO_MAIN`

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1981,14 +1981,14 @@ main(int argc, char** argv)
 }
 
 
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
 #endif  /* #ifndef TEST_NO_MAIN */
 
 #ifdef _MSC_VER
     #pragma warning(pop)
-#endif
-
-#ifdef __cplusplus
-    }  /* extern "C" */
 #endif
 
 #endif  /* #ifndef ACUTEST_H */


### PR DESCRIPTION
I noticed the following compilation error when utilizing the `TEST_NO_MAIN` macro to split test definitions over multiple files:

```
../third_party/acutest/include/acutest.h:1991:5: error: extraneous closing brace ('}')
    }  /* extern "C" */
    ^
1 error generated.
```

To reproduce, create the following files in one directory.

`tests.h`
```
#pragma once

void test_failure();
```

`tests.cc`
```
#include "tests.h"

#define TEST_NO_MAIN
#include "acutest.h"

void test_failure() {
    TEST_CHECK(1 == 2);
}
```

`test_runner.cc`
```
#include "acutest.h"

#include "tests.h"

TEST_LIST = {
    { "test_failure", test_failure },
    { NULL, NULL },
};
```

Before this change, I see the error:

```
$ c++ -I ../third_party/acutest/include tests.cc test_runner.cc
In file included from tests.cc:4:
../third_party/acutest/include/acutest.h:1991:5: error: extraneous closing brace ('}')
    }  /* extern "C" */
    ^
1 error generated.
```

Afterwards, I get the desired output:

```
$ c++ -I ../third_party/acutest/include tests.cc test_runner.cc
$ ./a.out
Test test_failure...                            [ FAILED ]
  tests.cc:7: 1 == 2... failed
FAILED: 1 of 1 unit tests has failed.
```