### PR TITLE
fix: cast int to size_t to quieten compilers.

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1828,7 +1828,7 @@ main(int argc, char** argv)
     for(i = 0; acutest_list_[i].func != NULL; i++)
         acutest_list_size_++;
 
-    acutest_test_data_ = (struct acutest_test_data_*)calloc(acutest_list_size_, sizeof(struct acutest_test_data_));
+    acutest_test_data_ = (struct acutest_test_data_*)calloc((size_t) acutest_list_size_, sizeof(struct acutest_test_data_));
     if(acutest_test_data_ == NULL) {
         fprintf(stderr, "Out of memory.\n");
         acutest_exit_(2);


### PR DESCRIPTION
In line 1831, a cast is required because `malloc()` expects a `size_t` as the first argument and an `int` was provided. The cast is perfectly safe here, as the number of tests can not be signed. Perhaps the better choice would have been to declare `acutest_list_size_` as an `unsigned` type. GCC-13.1 with `-Wconversion` complains about this.