### PR TITLE
Add max-msg run-time option

### DIFF
--- a/include/acutest.h
+++ b/include/acutest.h
@@ -1544,7 +1544,7 @@ acutest_help_(void)
     printf("                          2 ... As 1 and failed conditions (this is default)\n");
     printf("                          3 ... As 1 and all conditions (and extended summary)\n");
     printf("  -q, --quiet           Same as --verbose=0\n");
-    printf("      --max-msg=NUMBER  Set output limit to NUMBER\n");
+    printf("      --max-msg=NUMBER  Set message output limit to NUMBER (greater than 0)\n");
     printf("      --color[=WHEN]    Enable colorized output\n");
     printf("                          (WHEN is one of 'auto', 'always', 'never')\n");
     printf("      --no-color        Same as --color=never\n");
@@ -1573,7 +1573,7 @@ static const ACUTEST_CMDLINE_OPTION_ acutest_cmdline_options_[] = {
     { 'l',  "list",         'l', 0 },
     { 'v',  "verbose",      'v', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
     { 'q',  "quiet",        'q', 0 },
-    {  0,   "max-msg",      'm', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
+    {  0,   "max-msg",      'm', ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_ },
     {  0,   "color",        'c', ACUTEST_CMDLINE_OPTFLAG_OPTIONALARG_ },
     {  0,   "no-color",     'C', 0 },
     { 'h',  "help",         'h', 0 },
@@ -1646,7 +1646,12 @@ acutest_cmdline_callback_(int id, const char* arg)
             break;
 
         case 'm':
-            acutest_max_msg_ = (arg != NULL ? atoi(arg) : acutest_max_msg_);
+            acutest_max_msg_ = atoi(arg);
+            if (acutest_max_msg_ < 1) {
+                fprintf(stderr, "%s: Argument error '%s' for option --max-msg.\n", acutest_argv0_, arg);
+                fprintf(stderr, "Try '%s --help' for more information.\n", acutest_argv0_);
+                acutest_exit_(2);
+            }
             break;
 
         case 'c':


### PR DESCRIPTION

## Intro

Thank you @mity for a great tool that I use for every bit of C I work with.  
I wanted to get into contributing to open source projects for practice and internet points. Working on something I have a passion for and am familiar with seemed like a good place to start.

I have implemented the cmd line option for changing message output limit at run-time.  
Resolves #33

## New features

Added run-time option to change the max output message length without having to recompile.  Features:

- cmd line option `--max-msg=NUMBER`
- `TEST_MSG_MAXSIZE` is kept and used as default.  It can still be defined before acutest include.
- Added `--help` line for `--max-msg` usage
- Changes match formatting, style and layout of existing code.

Tested with:  
x64 Windows: gcc -Wall -Wextra -pedantic.

### Recreate issue and Verify solution

A test rig was setup to recreate a character limited test message.
Length of test message was larger than `TEST_MSG_MAXSIZE` (1024), increased to (1024 + 200 - 24) = 1200 characters (for a nice round number).  
On a failing test, as shown below, the # symbols represent long `TEST_MSG` output. As expected, the character count is 1024 - 1 (null terminated), defined by `TEST_MSG_MAXSIZE`.  It does not show the final sentence, confirming the long message output is limited by the compile-time defined value.

Normal default length limited output:
![image](https://github.com/user-attachments/assets/a80004a6-eb79-4b2f-9aa4-b9bf8610f0a8)


Using the new run-time option `--max-msg=1200`, the full message can be seen without having to recompile. It includes the closing words right up to the final period, verifying intended behaviour.

Run-time option extended output:
![image](https://github.com/user-attachments/assets/f0fff5f2-fead-49e0-bf81-6c33a19df2f2)

Re-compiling with pre-defined `TEST_MSG_MAXSIZE 1200` is confirmed to still operate as expected, needing no option to show full message.

Compile-time define extended output:
![image](https://github.com/user-attachments/assets/6391e5a1-1fa4-4bb3-9d7f-029ed9d4a3af)

## Bad input argument behaviour

There are several possible arg errors, nonsense input or genuine user misunderstanding. eg. user could misinterpret "--max-msg" is to set max possible etc.  To handle these type of cases, the `acutest_cmdline_options_` argument field was set to `ACUTEST_CMDLINE_OPTFLAG_REQUIREDARG_`. Other bad input is handled by setting exit value and usage hint output, matching other options.  

Bad arg outputs:

1. Missing arg
2. Empty NUMBER arg
3. Non-numeric NUMBER arg
4. Negative NUMBER arg

![image](https://github.com/user-attachments/assets/47a0156a-6ca0-4b88-aa8d-9268e89df14d)

`--help` options output includes `--max-msg` line:
![image](https://github.com/user-attachments/assets/9753479e-06c9-4d06-bb78-3698c160f3e9)

## Conclusion

This implementation meets requirements and is sufficiently verified for expected behaviour and error handling (IMO).  I have not tested on other machines although I do not see these changes causing any problem.  I will provide an update if anything arises from that testing.

Issue #34 is an equivalent feature for TEST_DUMP_MAXSIZE. I think it would be best to have that implemented for consistency.  I'm happy to do that one next.
